### PR TITLE
Feat/#69 자동 로그인 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,67 @@
+import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import BackgroundLayout from './common/BackgroundLayout';
 import MenuNav from './common/MenuNav';
 import Home from './pages/home/presentational/Home';
 import Login from './pages/login/container/Login';
 import KakaoAuth from './pages/login/container/KakaoAuth';
-import GoogleAuth from './pages/login/container/GoogleAuth'
-import { useSelector } from 'react-redux';
+import GoogleAuth from './pages/login/container/GoogleAuth';
+import { useDispatch, useSelector } from 'react-redux';
 import AiPages from './pages/AI-pages/presentation/AiPages';
 import AccountPage from './pages/Accountpage/presentational/AccountPage';
+import { getItem } from './utils/cookies';
+import axios from 'axios';
+import { signIn, updateToken } from './modules/login';
 
 export default function App() {
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    try {
+      // automatically login logic
+      if (isLoggedIn === false) {
+        const hasRefresh = getItem('has_refresh');
+        if (hasRefresh === 'true') {
+          // request new access token with posting refresh token(cookie)
+          axios
+            .get(`${process.env.REACT_APP_API_TEST}/auth/token`, { withCredentials: true })
+            .then((response) => {
+              const { accessToken, UID } = response.data;
+              dispatch(signIn(accessToken, UID));
+            })
+            .catch((error) => {
+              console.log(error);
+            });
+        }
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }, [dispatch, isLoggedIn]);
+
+  useEffect(() => {
+    try {
+      // request access token every 25 minutes
+      const interval = setInterval(() => {
+        axios
+          .post(`${process.env.REACT_APP_API_HOST}/auth/token`)
+          .then((response) => {
+            const { accessToken } = response.data;
+            dispatch(updateToken(accessToken));
+          })
+          .catch((error) => {
+            console.log(error);
+          });
+      }, 25 * 60 * 1000);
+
+      return () => {
+        clearInterval(interval);
+      };
+    } catch (error) {
+      console.log(error);
+    }
+  }, [dispatch]);
 
   return (
     <BackgroundLayout className="App">
@@ -20,7 +71,7 @@ export default function App() {
           <>
             <Route path="/" element={<Home />} />
             <Route path="/second" element={<AiPages />} />
-            <Route path="/third" element={<AccountPage/>} />
+            <Route path="/third" element={<AccountPage />} />
             <Route path="/fourth" element={'Community page'} />
             <Route path="/fifth" element={'Settings page'} />
             <Route path="*" element={'404'} />

--- a/src/modules/login.js
+++ b/src/modules/login.js
@@ -1,25 +1,25 @@
 /* Action Types */
-const AUTO_SIGN_IN = 'login/AUTO_SIGN_IN';
 const SIGN_IN = 'login/SING_IN';
 const SIGN_OUT = 'login/SIGN_OUT';
+const UPDATE_TOKEN = 'login/UPDATE_TOKEN';
 
 /* Action Creators */
-export const autoSignIn = (accessToken) => ({
-  type: AUTO_SIGN_IN,
-  isLoggedIn: true,
-  accessToken,
-});
-
-export const signIn = (accessToken) => ({
+export const signIn = (accessToken, UID) => ({
   type: SIGN_IN,
   isLoggedIn: true,
   accessToken,
+  UID,
 });
 
 export const signOut = () => ({
   type: SIGN_OUT,
   isLoggedIn: false,
   accessToken: null,
+});
+
+export const updateToken = (accessToken) => ({
+  type: UPDATE_TOKEN,
+  accessToken: accessToken,
 });
 
 /* Initial state */
@@ -37,17 +37,18 @@ export default function login(state = initialState, action) {
       return {
         ...state,
         isLoggedIn: action.isLoggedIn,
-      };
-    case AUTO_SIGN_IN:
-      return {
-        ...state,
         accessToken: action.accessToken,
-        isLoggedIn: action.isLoggedIn,
+        uid: action.UID,
       };
     case SIGN_OUT:
       return {
         ...state,
         isLoggedIn: action.isLoggedIn,
+      };
+    case UPDATE_TOKEN:
+      return {
+        ...state,
+        accessToken: action.accessToken,
       };
     default:
       return state;

--- a/src/pages/login/container/GoogleAuth.jsx
+++ b/src/pages/login/container/GoogleAuth.jsx
@@ -17,28 +17,31 @@ export default function GoogleAuth() {
       }
       // fetch auth code to back: use axios.post()
       axios
-        .post('http://ec2-13-209-73-79.ap-northeast-2.compute.amazonaws.com:8080/auth/callback', {
+        .post(`${process.env.REACT_APP_API_TEST}/auth/callback`, {
           code,
           loginType: 'GOOGLE',
         })
         .then((response) => {
-          console.log(response);
-          setItem('loginHistory', 'true'); // set cookie
-          dispatch(signIn());
-          console.log('login success!');
-          navigate('/', { replace: true });
+          if (response.data.isExistUser === true) {
+            // success login
+            const { accessToken, UID } = response.data;
+            dispatch(signIn(accessToken, UID));
+            setItem('has_refresh', 'true', 90);
+            navigate('/', { replace: true });
+          } else if (response.data.isExistUser === false) {
+            navigate('/sign-up', { replace: true });
+          }
         })
         .catch((error) => {
           // network communication error
-          console.log(error);
-          console.log('post error!');
+          console.log('newtwork error!', error);
           navigate('/', { replace: true });
         });
     } catch (error) {
-      console.log(error);
-      console.log('login error!');
+      console.log('unexpected error!', error);
       navigate('/', { replace: true });
     }
   }, [dispatch, navigate]);
+
   return <div style={{ margin: '50%', color: 'white' }}>{'로그인 중입니다...'}</div>;
 }

--- a/src/pages/login/container/KakaoAuth.jsx
+++ b/src/pages/login/container/KakaoAuth.jsx
@@ -17,26 +17,28 @@ export default function KakaoAuth() {
       }
       // fetch auth code to back: use axios.post()
       axios
-        .post('http://ec2-13-209-73-79.ap-northeast-2.compute.amazonaws.com:8080/auth/callback', {
+        .post(`${process.env.REACT_APP_API_TEST}/auth/callback`, {
           code,
           loginType: 'KAKAO',
         })
         .then((response) => {
-          console.log(response);
-          setItem('loginHistory', 'true'); // set cookie
-          dispatch(signIn());
-          console.log('login success!');
-          navigate('/', { replace: true });
+          if (response.data.isExistUser === true) {
+            // success login
+            const { accessToken, UID } = response.data;
+            dispatch(signIn(accessToken, UID));
+            setItem('has_refresh', 'true', 90);
+            navigate('/', { replace: true });
+          } else if (response.data.isExistUser === false) {
+            navigate('/sign-up', { replace: true });
+          }
         })
         .catch((error) => {
           // network communication error
-          console.log(error);
-          console.log('post error!');
+          console.log('newtwork error!', error);
           navigate('/', { replace: true });
         });
     } catch (error) {
-      console.log(error);
-      console.log('login error!');
+      console.log('unexpected error!', error);
       navigate('/', { replace: true });
     }
   }, [dispatch, navigate]);

--- a/src/pages/login/container/Login.jsx
+++ b/src/pages/login/container/Login.jsx
@@ -11,13 +11,13 @@ export default function Login() {
   return (
     <LoginPageLayout>
       <Logo></Logo>
-      <LayoutedKakao href="http://ec2-13-209-73-79.ap-northeast-2.compute.amazonaws.com:8080/auth/KAKAO" />
-      <LayoutedGoogle href="http://ec2-13-209-73-79.ap-northeast-2.compute.amazonaws.com:8080/auth/GOOGLE"/>
+      <LayoutedKakao href={`${process.env.REACT_APP_API_TEST}/auth/KAKAO`} />
+      <LayoutedGoogle href={`${process.env.REACT_APP_API_TEST}/auth/GOOGLE`} />
       <button
         onClick={() => {
           // 개발용 로그인 스킵 버튼.
           // set isLoggedIn True
-          dispatch(signIn('fakeToken'));
+          dispatch(signIn('fakeToken', 'fakeUID'));
         }}
       >
         Skip

--- a/src/utils/cookies.js
+++ b/src/utils/cookies.js
@@ -7,7 +7,16 @@ export const getItem = (key) => {
 };
 
 export const setItem = (key, value, numberOfDays) => {
-  const now = new Date();
-  now.setTime(now.getTime() + numberOfDays * 60 * 60 * 24 * 1000);
-  document.cookie = `${key}=${value}; expires=${now.toUTCString()}; path=/`;
+  if (!!numberOfDays) {
+    const now = new Date();
+    now.setTime(now.getTime() + numberOfDays * 60 * 60 * 24 * 1000);
+    document.cookie = `${key}=${value}; expires=${now.toUTCString()}; path=/`;
+  } else {
+    // session cookie
+    document.cookie = `${key}=${value}; path=/`;
+  }
+};
+
+export const deleteItem = (key) => {
+  document.cookie = `${key}=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/`;
 };


### PR DESCRIPTION
1. 클라이언트가 보유한 리프레시 토큰을 이용해 액세스 토큰을 요청하는 방법으로 자동 로그인을 구현 하였습니다.
    App.js에서 access token의 만료시간(30분) 5분 전, 즉 25분마다 새로운 access token을 요청합니다.
2. express 서버를 이용해 테스트를 위해 백엔드 호스트 주소를 `process.env.REACT_APP_API_TEST`로 사용하였습니다.
3. util폴더의 cookie의 쿠키를 생성하는 함수인 setItem에 세션 쿠키를 생성하는 기능을 추가하였습니다. 만료시간을 명시하지 않으면 세션 쿠키를 생성합니다.

이상한 부분 지적해주시면 감사하겠습니다!!
늦어서 죄송합니다 😢 

앞으로 해야할 일)
- 회원가입 폼
- 로그아웃