### PR TITLE
feat: devlop 브랜치, master 브랜치 ci 구현

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy develop
 on:
   push:
     branches:
@@ -30,11 +30,20 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm install
 
+      - name: give permission
+        run: chmod +x scripts/makeEnv.sh
+
+      - name: make envrionment variable
+        run: ./scripts/makeEnv.sh ${{ secrets.API_DEV }}
+
       - name: run build
         run: CI='' npm run build
 
+      - name: change name build folder to build-develop
+        run: mv build build-develop
+
       - name: zip create
-        run: zip -qq -r ./build-fe.zip .
+        run: zip -qq -r ./develop.zip build-develop appspec.yml scripts .env
         shell: bash
 
       - name: Configure AWS credentials
@@ -49,11 +58,11 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS_KEY }}
         run: |
-          aws s3 cp --region ap-northeast-2 ./build-fe.zip s3://choha/fe/build-fe.zip
+          aws s3 cp --region ap-northeast-2 ./develop.zip s3://motobi-front-develop/develop/develop.zip
 
       - name: Deploy
         run: aws deploy create-deployment
-          --application-name codedeploy_gh
+          --application-name motobi_front_deploy_develop
           --deployment-config-name CodeDeployDefault.AllAtOnce
-          --deployment-group-name deploy_he
-          --s3-location bucket=choha,key=fe/build-fe.zip,bundleType=zip
+          --deployment-group-name motobi
+          --s3-location bucket=motobi-front-develop,key=develop/develop.zip,bundleType=zip

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -1,0 +1,68 @@
+name: Deploy master
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      # setup node.js envs
+      - name: use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ secrets.NODE_VERSION }}
+
+      - name: Check Node
+        run: node -v
+
+      - name: cache node modules
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: node_modules
+          key: npm-package-${{ hashFiles('**/package-lock.json') }}
+
+      - name: install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install
+
+      - name: give permission
+        run: chmod +x scripts/makeEnv.sh
+
+      - name: make envrionment variable
+        run: ./scripts/makeEnv.sh ${{ secrets.API_PRODUCT }}
+
+      - name: run build
+        run: CI='' npm run build
+
+      - name: change name build folder to build-master
+        run: mv build build-master
+
+      - name: zip create
+        run: zip -qq -r ./master.zip build-master appspec.yml scripts
+        shell: bash
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 cp --region ap-northeast-2 ./master.zip s3://motobi-front-develop/master/master.zip
+
+      - name: Deploy
+        run: aws deploy create-deployment
+          --application-name motobi_front_deploy_develop
+          --deployment-config-name CodeDeployDefault.AllAtOnce
+          --deployment-group-name motobi
+          --s3-location bucket=motobi-front-develop,key=master/master.zip,bundleType=zip

--- a/appspec.yml
+++ b/appspec.yml
@@ -2,10 +2,21 @@ version: 0.0
 os: linux
 files:
   - source: /
-    destination: /home/ubuntu/dfe
-    overwrite: yes
+    destination: /root/deploy_tmp
+    overwrite: true
 permissions:
-  - object: /home/ubuntu/dfe
+  - object: /root/motobi_develop
     owner: root
     group: root
     mode: 755
+  - object: /root/motobi_master
+    owner: root
+    group: root
+    mode: 755
+hooks:
+  BeforeInstall:
+    - location: scripts/beforeDeploy.sh
+      runas: root
+  AfterInstall:
+    - location: scripts/afterDeploy.sh
+      runas: root

--- a/scripts/afterDeploy.sh
+++ b/scripts/afterDeploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+find /root/deploy_tmp -maxdepth 1 -type d -name "build*" -printf '%f' | xargs -i{} rm -rf "/root/{}"
+mv /root/deploy_tmp/build* /root/
+rm -rf /root/deploy_tmp
+# rm /root/appspec.yml

--- a/scripts/beforeDeploy.sh
+++ b/scripts/beforeDeploy.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mkdir /root/deploy_tmp

--- a/scripts/makeEnv.sh
+++ b/scripts/makeEnv.sh
@@ -1,0 +1,9 @@
+# !/bin/bash
+if [ $# -eq 1 ]; then
+    echo "REACT_APP_API=$1" > .env
+    # echo REACT_APP_API=localhost > .env
+else
+    echo "$0 arguments is invalid."
+fi
+
+ls -a

--- a/src/pages/login/container/GoogleAuth.jsx
+++ b/src/pages/login/container/GoogleAuth.jsx
@@ -17,7 +17,7 @@ export default function GoogleAuth() {
       }
       // fetch auth code to back: use axios.post()
       axios
-        .post(`${process.env.REACT_APP_API_TEST}/auth/callback`, {
+        .post(`${process.env.REACT_APP_API}/auth/callback`, {
           code,
           loginType: 'GOOGLE',
         })

--- a/src/pages/login/container/KakaoAuth.jsx
+++ b/src/pages/login/container/KakaoAuth.jsx
@@ -17,7 +17,7 @@ export default function KakaoAuth() {
       }
       // fetch auth code to back: use axios.post()
       axios
-        .post(`${process.env.REACT_APP_API_TEST}/auth/callback`, {
+        .post(`${process.env.REACT_APP_API}/auth/callback`, {
           code,
           loginType: 'KAKAO',
         })

--- a/src/pages/login/container/Login.jsx
+++ b/src/pages/login/container/Login.jsx
@@ -11,8 +11,8 @@ export default function Login() {
   return (
     <LoginPageLayout>
       <Logo></Logo>
-      <LayoutedKakao href={`${process.env.REACT_APP_API_TEST}/auth/KAKAO`} />
-      <LayoutedGoogle href={`${process.env.REACT_APP_API_TEST}/auth/GOOGLE`} />
+      <LayoutedKakao href={`${process.env.REACT_APP_API}/auth/KAKAO`} />
+      <LayoutedGoogle href={`${process.env.REACT_APP_API}/auth/GOOGLE`} />
       <button
         onClick={() => {
           // 개발용 로그인 스킵 버튼.


### PR DESCRIPTION
#89 

[develop](http://datasci.kw.ac.kr:6024)
[master](http://datasci.kw.ac.kr:6025)
develop 브랜치와 master 브랜치 ci/cd 구현하였습니다. 무중단 배포는 아닙니다...
서버는 DSL 연구실 NAS 이용중이고,  6024포트는 develop, 6025포트는 master를 가리키도록 했습니다.
백엔드 주소는 아래와 같이 깃허브 저장소 변수를 이용중입니다.(API_DEV, API_PRODUCT)
현재 둘 다 http://localhost:8080 을 가리키도록 했습니다.
![image](https://user-images.githubusercontent.com/64854140/175869109-119ebc6c-2fdc-44d6-95c1-11989fb17e1e.png)

프로젝트 내에 scripts폴더가 추가되었는데 자동 배포에 이용되는 명령어 스크립트들을 적어놨습니다.

