### PR TITLE
[hotfix] 네비게이션 position css 속성 삭제

### DIFF
--- a/src/common/MenuNav.jsx
+++ b/src/common/MenuNav.jsx
@@ -48,10 +48,6 @@ const StyledMenubar = styled.nav`
   overflow: hidden;
   height: 70px;
   border-top: 2px solid rgb(184, 168, 142);
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
 `;
 
 const StyledMenuButton = styled(Link)`


### PR DESCRIPTION
네비게이션 컴포넌트의 postion css 속성을 삭제했습니다.